### PR TITLE
Update OnedriveStorageAPIService.php

### DIFF
--- a/lib/Service/OnedriveStorageAPIService.php
+++ b/lib/Service/OnedriveStorageAPIService.php
@@ -255,7 +255,7 @@ class OnedriveStorageAPIService {
 			$folder = $topFolder->get($path);
 		}
 
-		$encPath = urlencode($path);
+		$encPath = rawurlencode($path);
 		$reqPath = ($encPath === '')
 			? ''
 			: ':' . $encPath . ':';


### PR DESCRIPTION
Resolves #28 

Replace urlencode() function with rawurlencode() to correct 404 error when there is a space in a folder name.